### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,4 +1,6 @@
 name: Proof HTML
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "cbio-skin-canc",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Analysis of Skin Cancer Data"
 }


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/cbio-skin-canc/security/code-scanning/1](https://github.com/conorheffron/cbio-skin-canc/security/code-scanning/1)

To fix the problem, we should add a `permissions` key to the workflow to explicitly set the minimum privileges required. Since the workflow appears to only run a linter on HTML files and doesn't require write access or perform any privileged operations, the most appropriate setting is `contents: read`. This can be set at the workflow root (so it applies to all jobs) or, equivalently, at the job level. Since there is only a single job, and since best practice is to set at the root unless finer granularity is needed, we will add:

```yaml
permissions:
  contents: read
```

Directly after the workflow `name` and before `on:` in `.github/workflows/proof-html.yml` (i.e., after line 1 and before line 2).

No additional methods or imports are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
